### PR TITLE
To remove default networks on Windows Server 2016

### DIFF
--- a/virtualization/windowscontainers/manage-docker/configure-docker-daemon.md
+++ b/virtualization/windowscontainers/manage-docker/configure-docker-daemon.md
@@ -208,6 +208,12 @@ Docker をアンインストールした後は、Docker の既定のネットワ
 Get-HNSNetwork | Remove-HNSNetwork
 ```
 
+Windows Server 2016 の場合は、次のコマンドレッドを使用します。
+
+```powershell
+Get-ContainerNetwork | Remove-ContainerNetwork
+```
+
 次のコマンドレットを実行して、Docker のプログラム データをお使いのシステムから削除します。
 
 ```powershell


### PR DESCRIPTION
"Get-HNSNetwork | Remove-HNSNetwork" is available on Windows 10 RS5 later. Then the cmdlet doesn't work on Windows Server 2016. "Get-ContainerNetwork | Remove-ContainerNetwork" works fine on Windows Server 2016.